### PR TITLE
fix: enable auto-merge after approval

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,7 +3,9 @@ name: 🤖 Enable Auto-Merge
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request: {}
+  pull_request_review:
+    types:
+      - submitted
 
 permissions:
   contents: read
@@ -11,7 +13,10 @@ permissions:
 jobs:
   automerge:
     name: Enable auto-merge
-    if: github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]')
+    if: >-
+      github.event.review.state == 'approved' &&
+      (github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/moduleroot/.github/workflows/automerge.yml.erb
+++ b/moduleroot/.github/workflows/automerge.yml.erb
@@ -6,7 +6,9 @@ name: 🤖 Enable Auto-Merge
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request: {}
+  pull_request_review:
+    types:
+      - submitted
 
 permissions:
   contents: read
@@ -14,7 +16,10 @@ permissions:
 jobs:
   automerge:
     name: Enable auto-merge
-    if: github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]')
+    if: >-
+      github.event.review.state == 'approved' &&
+      (github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Trigger the auto-merge workflow from approved reviews so GitHub adds dependency updates to the merge queue only after approval.

This is to prevent "to early" enabled automerges to get stuck in the merge_queue.